### PR TITLE
Markdown syntax for xml and javascript

### DIFF
--- a/hal_specification.md
+++ b/hal_specification.md
@@ -80,7 +80,8 @@ structured:
 
 Here is how you could represent a collection of orders with the JSON variant of HAL:
 
-{% highlight javascript %}
+
+```javascript
 {
   "_links": {
     "self": { "href": "/orders" },
@@ -115,11 +116,12 @@ Here is how you could represent a collection of orders with the JSON variant of 
     }]
   }
 }
-{% endhighlight %}
+```
+
 
 Here is the same example using the XML variant of HAL:
 
-{% highlight xml %}
+```xml
 <resource href="/orders">
   <link rel="next" href="/orders?page=2" />
   <link rel="find" href="/orders{?id}" templated="true" />
@@ -142,7 +144,7 @@ Here is the same example using the XML variant of HAL:
     <status>processing</status>
   </resource>
 </resource>
-{% endhighlight %}
+```
 
 ## How to use HAL
 
@@ -282,14 +284,14 @@ Further details on the JSON variant of HAL:
 ## Minimum Valid Representation
 
 ### JSON
-{% highlight javascript %}
+```javascript
 { "_links": { "self": { "href": "http://example.com/" } } }
-{% endhighlight %}
+```
 
 ### XML
-{% highlight xml %}
+```xml
 <resource href="http://example.com/" />
-{% endhighlight %}
+```
 
 ## Recommendations
 
@@ -303,9 +305,9 @@ For XML, the [CURIE syntax][10] MAY be used for brevity.
 
 For JSON, a 'curie' link can be used like so:
 
-{% highlight javascript %}
+```javascript
 { ... '_links' : { 'curie': { 'href' : 'http://example.com/rels/{relation}', 'name': 'ex' }, ... }, ... }
-{% endhighlight %}
+```
 
 ## Acknowledgements
 


### PR DESCRIPTION
just modified your markdown so that it would format code correctly on github.
