### PR TITLE
json example adjusted to xml example

### DIFF
--- a/hal_specification.md
+++ b/hal_specification.md
@@ -94,7 +94,7 @@ Here is how you could represent a collection of orders with the JSON variant of 
   currentlyProcessing: 14,
   shippedToday: 20,
   "_embedded": {
-   "orders": [{
+   "order": [{
        "_links": {
          "self": { "href": "/orders/123" },
          "basket": { "href": "/baskets/98712" },


### PR DESCRIPTION
The rel in case of the json example does state "orders" and not "order". If I properly understand the XML example, I guess it should be "order".
