### PR TITLE
Formatted example JSON

### DIFF
--- a/hal_specification.md
+++ b/hal_specification.md
@@ -85,38 +85,44 @@ Here is how you could represent a collection of orders with the JSON variant of 
 
 ```javascript
 {
-  "_links": {
-    "self": { "href": "/orders" },
-    "next": { "href": "/orders?page=2" },
-    "find": { "href": "/orders{?id}", "templated": true },
-    "admin": [
-      { "href": "/admins/2", "title": "Fred" },
-      { "href": "/admins/5", "title": "Kate" }
-    ]
-  },
-  currentlyProcessing: 14,
-  shippedToday: 20,
-  "_embedded": {
-   "order": [{
-       "_links": {
-         "self": { "href": "/orders/123" },
-         "basket": { "href": "/baskets/98712" },
-         "customer": { "href": "/customers/7809" }
-       },
-       "total": 30.00,
-       "currency": "USD",
-       "status": "shipped",
-     },{
-       "_links": {
-         "self": { "href": "/orders/124" },
-         "basket": { "href": "/baskets/97213" },
-         "customer": { "href": "/customers/12369" }
-       },
-       "total": 20.00,
-       "currency": "USD",
-       "status": "processing"
-    }]
-  }
+    "_links": {
+        "self": { "href": "/orders" },
+        "next": { "href": "/orders?page=2" },
+        "find": {
+            "href": "/orders{?id}",
+            "templated": true
+        },
+        "admin": [{
+            "href": "/admins/2",
+            "title": "Fred"
+        }, {
+            "href": "/admins/5",
+            "title": "Kate"
+        }]
+    },
+    "currentlyProcessing": 14,
+    "shippedToday": 20,
+    "_embedded": {
+        "order": [{
+            "_links": {
+                "self": { "href": "/orders/123" },
+                "basket": { "href": "/baskets/98712" },
+                "customer": { "href": "/customers/7809" }
+            },
+            "total": 30.00,
+            "currency": "USD",
+            "status": "shipped"
+        }, {
+            "_links": {
+                "self": { "href": "/orders/124" },
+                "basket": { "href": "/baskets/97213" },
+                "customer": { "href": "/customers/12369" }
+            },
+            "total": 20.00,
+            "currency": "USD",
+            "status": "processing"
+        }]
+    }
 }
 ```
 


### PR DESCRIPTION
There were two unquoted attribute names and a trailing comma which the example a valid JavaScript object literal, but invalid JSON object. I also tried to make the formatting more consistent.
