### PR TITLE
Add dougrain to implementation list

### DIFF
--- a/hal_specification.md
+++ b/hal_specification.md
@@ -36,6 +36,7 @@ The JSON variant of HAL (application/hal+json) has now been published as an inte
 * [(Objective-C) HyperBek][31]
 * [(Eiffel) HAL][22]
 * [(Clojure) halresource][32]
+* [(Python) Dougrain][33]
 * [Test Representations][25]
 * [HAL Browser][26]
 
@@ -349,3 +350,4 @@ Thanks to Darrel Miller and Mike Amundsen for their invaluable feedback.
  [30]: http://gotohal.net/
  [31]: https://bitbucket.org/dcutting/hyperbek
  [32]: https://github.com/cndreisbach/halresource
+ [33]: https://github.com/wharris/dougrain


### PR DESCRIPTION
Dougrain is a parser and generator implementation of Draft 5 in Python. Not mine, but I like it a lot. :)
